### PR TITLE
BAH-2429 | updated the byte size to 25MB to store data in health information

### DIFF
--- a/src/In.ProjectEKA.HipService/appsettings.json
+++ b/src/In.ProjectEKA.HipService/appsettings.json
@@ -42,7 +42,7 @@
     "Password": "guest"
   },
   "dataFlow": {
-    "dataSizeLimitInMbs": 5
+    "dataSizeLimitInMbs": 27
   },
   "hip": {
     "url": "$HIP_URL"


### PR DESCRIPTION
The limit is added as 27 because for 25 MB, it is 26,214,400 Bytes. Here it will allow upto 27,000,000 Bytes