### PR TITLE
BAH-3165 | Add. mcr.microsoft.com/dotnet/sdk:7.0 As build-env

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.401 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers


### PR DESCRIPTION
In this PR, the following modifications have been implemented:

**build-env Update**: The build-env image `mcr.microsoft.com/dotnet/sdk:7.0` has been upgraded from version `6.0.401` to version `7.0`. 