### PR TITLE
BAH-4120 | Migrate Scan and Share Feature to use ABDM v3 APIs

### DIFF
--- a/src/In.ProjectEKA.HipService/Common/Constants.cs
+++ b/src/In.ProjectEKA.HipService/Common/Constants.cs
@@ -17,7 +17,7 @@ namespace In.ProjectEKA.HipService.Common
         public const string APP_PATH_CREATE_ABHA_ADDRESS = "/" + VERSION_V3 + "/hip/createAbhaAddress";
         public const string APP_PATH_GET_ABHA_CARD = "/" + VERSION_V3 + "/hip/getAbhaCard";
         
-        public const string PATH_SESSIONS = CURRENT_VERSION + "/sessions";
+        public const string PATH_SESSIONS =  "api/hiecm/gateway/"+VERSION_V3+"/sessions";
         public const string PATH_CARE_CONTEXTS_DISCOVER = CURRENT_VERSION + "/care-contexts/discover";
         public const string PATH_CONSENTS_HIP = CURRENT_VERSION + "/consents/hip/notify";
         public const string PATH_LINKS_LINK_INIT = CURRENT_VERSION + "/links/link/init";

--- a/src/In.ProjectEKA.HipService/Common/Constants.cs
+++ b/src/In.ProjectEKA.HipService/Common/Constants.cs
@@ -86,9 +86,9 @@ namespace In.ProjectEKA.HipService.Common
         public const string DEEPLINK_URL = "https://link.to.health.records";
         public const string PATH_PATIENT_NOTIFY = "/" + CURRENT_VERSION + "/patients/status/notify";
         public const string PATH_PATIENT_ON_NOTIFY = "/" + CURRENT_VERSION + "/patients/status/on-notify";
-        public const string PATH_PROFILE_SHARE = "/" + UPDATED_VERSION + "/patients/profile/share";
-        public const string PATH_PROFILE_ON_SHARE = "/" + UPDATED_VERSION + "/patients/profile/on-share";
-        public const string PATH_PROFILE_FETCH = "/" + CURRENT_VERSION + "/patients/profile/fetch";
+        public const string PATH_PROFILE_SHARE = "/api/" + VERSION_V3 + "/hip/patient/share";
+        public const string PATH_PROFILE_ON_SHARE = "/api/hiecm/patient-share/"+VERSION_V3 +"/on-share";
+        public const string GET_PATIENT_QUEUE = "/" + VERSION_V3 + "/hip/getPatientQueue";
 
         public const string ABHA_SERVICE_CERT_URL = "/" + VERSION_V3 + "/profile/public/certificate";
         public const string ENROLLMENT_REQUEST_OTP = "/" + VERSION_V3 + "/enrollment/request/otp";

--- a/src/In.ProjectEKA.HipService/Common/HttpRequestHelper.cs
+++ b/src/In.ProjectEKA.HipService/Common/HttpRequestHelper.cs
@@ -50,7 +50,7 @@ namespace In.ProjectEKA.HipService.Common
             if (transactionId != null)
                 httpRequestMessage.Headers.Add("Transaction_Id", transactionId);
             httpRequestMessage.Headers.Add("REQUEST-ID", Guid.NewGuid().ToString());
-            httpRequestMessage.Headers.Add("TIMESTAMP", DateTime.Now.ToString(TIMESTAMP_FORMAT));
+            httpRequestMessage.Headers.Add("TIMESTAMP", DateTime.UtcNow.ToString(TIMESTAMP_FORMAT));
             return httpRequestMessage;
         }
 

--- a/src/In.ProjectEKA.HipService/Common/Model/GatewayAuthHttpHandler.cs
+++ b/src/In.ProjectEKA.HipService/Common/Model/GatewayAuthHttpHandler.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Log = Serilog.Log;
+
+namespace In.ProjectEKA.HipService.Common.Model;
+
+public class GatewayAuthHttpHandler : HttpClientHandler
+{
+    public GatewayAuthHttpHandler(IConfiguration configuration)
+    {
+        Configuration = configuration;
+    }
+
+    private IConfiguration Configuration;
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        request.Headers.Add("X-CM-ID", Configuration.GetValue<string>("Gateway:cmSuffix"));
+        request.Headers.Add("REQUEST-ID", Guid.NewGuid().ToString());
+        request.Headers.Add("TIMESTAMP", DateTime.UtcNow.ToString(Constants.TIMESTAMP_FORMAT));
+        HttpResponseMessage responseMessage = await base.SendAsync(request, cancellationToken);
+        return responseMessage;
+    }
+}

--- a/src/In.ProjectEKA.HipService/Gateway/GatewayClient.cs
+++ b/src/In.ProjectEKA.HipService/Gateway/GatewayClient.cs
@@ -39,7 +39,8 @@ namespace In.ProjectEKA.HipService.Gateway
                 var json = JsonConvert.SerializeObject(new
                 {
                     clientId = configuration.ClientId,
-                    clientSecret = configuration.ClientSecret
+                    clientSecret = configuration.ClientSecret,
+                    grantType = "client_credentials"
                 }, new JsonSerializerSettings
                 {
                     NullValueHandling = NullValueHandling.Ignore,
@@ -56,6 +57,9 @@ namespace In.ProjectEKA.HipService.Gateway
                 };
                 if (correlationId != null)
                     message.Headers.Add(Constants.CORRELATION_ID, correlationId);
+                message.Headers.Add("REQUEST-ID", Guid.NewGuid().ToString());
+                message.Headers.Add("TIMESTAMP", DateTime.Now.ToString(Constants.TIMESTAMP_FORMAT));
+                message.Headers.Add("X-CM-ID", configuration.CmSuffix);
                 var responseMessage = await httpClient.SendAsync(message).ConfigureAwait(false);
                 var response = await responseMessage.Content.ReadAsStringAsync();
 

--- a/src/In.ProjectEKA.HipService/Gateway/GatewayClient.cs
+++ b/src/In.ProjectEKA.HipService/Gateway/GatewayClient.cs
@@ -58,7 +58,7 @@ namespace In.ProjectEKA.HipService.Gateway
                 if (correlationId != null)
                     message.Headers.Add(Constants.CORRELATION_ID, correlationId);
                 message.Headers.Add("REQUEST-ID", Guid.NewGuid().ToString());
-                message.Headers.Add("TIMESTAMP", DateTime.Now.ToString(Constants.TIMESTAMP_FORMAT));
+                message.Headers.Add("TIMESTAMP", DateTime.UtcNow.ToString(Constants.TIMESTAMP_FORMAT));
                 message.Headers.Add("X-CM-ID", configuration.CmSuffix);
                 var responseMessage = await httpClient.SendAsync(message).ConfigureAwait(false);
                 var response = await responseMessage.Content.ReadAsStringAsync();

--- a/src/In.ProjectEKA.HipService/Patient/IPatientProfileService.cs
+++ b/src/In.ProjectEKA.HipService/Patient/IPatientProfileService.cs
@@ -6,7 +6,7 @@ namespace In.ProjectEKA.HipService.Patient
 {
     public interface IPatientProfileService
     {
-        Task<int> SavePatient(ShareProfileRequest shareProfileRequest);
+        Task<int> SavePatient(ShareProfileRequest shareProfileRequest, string requestId, string timestamp);
         bool IsValidRequest(ShareProfileRequest shareProfileRequest);
         Task<List<PatientQueue>> GetPatientQueue();
         Task linkToken(PatientDemographics patientDemographics);

--- a/src/In.ProjectEKA.HipService/Patient/IPatientProfileService.cs
+++ b/src/In.ProjectEKA.HipService/Patient/IPatientProfileService.cs
@@ -9,6 +9,5 @@ namespace In.ProjectEKA.HipService.Patient
         Task<int> SavePatient(ShareProfileRequest shareProfileRequest, string requestId, string timestamp);
         bool IsValidRequest(ShareProfileRequest shareProfileRequest);
         Task<List<PatientQueue>> GetPatientQueue();
-        Task linkToken(PatientDemographics patientDemographics);
     }
 }

--- a/src/In.ProjectEKA.HipService/Patient/Model/PatientDemographics.cs
+++ b/src/In.ProjectEKA.HipService/Patient/Model/PatientDemographics.cs
@@ -5,34 +5,35 @@ namespace In.ProjectEKA.HipService.Patient.Model
 {
     public class PatientDemographics
     {
-        public string HealthId { get; }
-        public string HealthIdNumber { get; }
+        public string AbhaAddress { get; }
+        public string AbhaNumber { get; }
         public string Name { get; }
         public string Gender { get; }
         public Address Address { get; }
         public int YearOfBirth { get; }
         public int? DayOfBirth { get; }
         public int? MonthOfBirth { get; }
-        public List<Identifier> Identifiers { get; }
+        public string PhoneNumber { get; }
 
         public PatientDemographics(string name,
             string gender,
-            string healthId,
+            string abhaAddress,
             Address address,
             int yearOfBirth,
             int? dayOfBirth,
             int? monthOfBirth,
-            List<Identifier> identifiers, string healthIdNumber)
+            string abhaNumber,
+            string phoneNumber)
         {
             Name = name;
             Gender = gender;
-            HealthId = healthId;
+            AbhaAddress = abhaAddress;
             Address = address;
             YearOfBirth = yearOfBirth;
             DayOfBirth = dayOfBirth;
             MonthOfBirth = monthOfBirth;
-            Identifiers = identifiers;
-            HealthIdNumber = healthIdNumber;
+            PhoneNumber = phoneNumber;
+            AbhaNumber = abhaNumber;
         }
     }
 }

--- a/src/In.ProjectEKA.HipService/Patient/Model/Profile.cs
+++ b/src/In.ProjectEKA.HipService/Patient/Model/Profile.cs
@@ -2,12 +2,10 @@ namespace In.ProjectEKA.HipService.Patient.Model
 {
     public class Profile
     {
-        public string HipCode { get; }
-        public PatientDemographics PatientDemographics { get; }
-        public Profile(string hipCode, PatientDemographics patient)
+        public PatientDemographics Patient { get; }
+        public Profile(PatientDemographics patient)
         {
-            HipCode = hipCode;
-            PatientDemographics = patient;
+            Patient = patient;
         }
     }
 }

--- a/src/In.ProjectEKA.HipService/Patient/Model/ProfileShareAcknowledgement.cs
+++ b/src/In.ProjectEKA.HipService/Patient/Model/ProfileShareAcknowledgement.cs
@@ -2,14 +2,29 @@ namespace In.ProjectEKA.HipService.Patient.Model
 {
     public class ProfileShareAcknowledgement
     {
-        public ProfileShareAcknowledgement(string status,string healthId, string tokenNumber)
+        public ProfileShareAcknowledgement(string status, string abhaAddress, ProfileShareAckProfile profile)
         {
             Status = status;
-            HealthId = healthId;
-            TokenNumber = tokenNumber;
+            AbhaAddress = abhaAddress;
+            Profile = profile;
         }
+        
         public string Status { get; }
-        public string HealthId { get; }
+        public string AbhaAddress { get; }
+        public ProfileShareAckProfile Profile { get; }
+    }
+
+    public class ProfileShareAckProfile
+    {
+        public string Context { get; }
         public string TokenNumber { get; }
+        public string Expiry { get; }
+
+        public ProfileShareAckProfile(string context, string tokenNumber, string expiry)
+        {
+            Context = context;
+            TokenNumber = tokenNumber;
+            Expiry = expiry;
+        }
     }
 }

--- a/src/In.ProjectEKA.HipService/Patient/Model/ProfileShareConfirmation.cs
+++ b/src/In.ProjectEKA.HipService/Patient/Model/ProfileShareConfirmation.cs
@@ -5,19 +5,14 @@ namespace In.ProjectEKA.HipService.Patient.Model
 {
     public class ProfileShareConfirmation
     {
-        public ProfileShareConfirmation(string requestId, string timestamp,
-            ProfileShareAcknowledgement acknowledgement, Error error, Resp resp)
+        public ProfileShareConfirmation(ProfileShareAcknowledgement acknowledgement, Error error, Resp resp)
         {
-            RequestId = requestId;
-            Timestamp = timestamp;
             Acknowledgement = acknowledgement;
             Error = error;
-            Resp = resp;
+            Response = resp;
         }
-        public string RequestId { get; }
-        public string Timestamp { get; }
         public Error Error { get; }
-        public Resp Resp { get; }
+        public Resp Response { get; }
         public ProfileShareAcknowledgement Acknowledgement { get; }
     }
 }

--- a/src/In.ProjectEKA.HipService/Patient/Model/ShareProfileRequest.cs
+++ b/src/In.ProjectEKA.HipService/Patient/Model/ShareProfileRequest.cs
@@ -6,16 +6,34 @@ namespace In.ProjectEKA.HipService.Patient.Model
 {
     public class ShareProfileRequest
     {
-        [Required]
-        public string RequestId { get;}
-        [Required]
-        public DateTime? Timestamp { get;}
-        public Profile Profile { get; }
-        public ShareProfileRequest(string requestId,DateTime? timestamp, Profile profile)
+        public string Intent { get; }
+
+        public ShareProfileMetadata Metadata { get; }
+        [Required] public Profile Profile { get; }
+
+        public ShareProfileRequest(string intent, ShareProfileMetadata metadata, Profile profile)
         {
-            RequestId = requestId;
-            Timestamp = timestamp;
+            Intent = intent;
+            Metadata = metadata;
             Profile = profile;
+        }
+    }
+
+    public class ShareProfileMetadata
+    {
+        public string HipId { get; }
+        public string Context { get; }
+        public string HprId { get; }
+        public string Latitude { get; }
+        public string Longitude { get; }
+
+        public ShareProfileMetadata(string hipId, string context, string hprId, string latitude, string longitude)
+        {
+            HipId = hipId;
+            Context = context;
+            HprId = hprId;
+            Latitude = latitude;
+            Longitude = longitude;
         }
     }
 }

--- a/src/In.ProjectEKA.HipService/Patient/PatientProfileService.cs
+++ b/src/In.ProjectEKA.HipService/Patient/PatientProfileService.cs
@@ -36,13 +36,11 @@ namespace In.ProjectEKA.HipService.Patient
             this.hipConfiguration = hipConfiguration;
         }
 
-        public async Task<int> SavePatient(ShareProfileRequest shareProfileRequest)
+        public async Task<int> SavePatient(ShareProfileRequest shareProfileRequest, string requestId, string timestamp)
         {
-            var requesId = shareProfileRequest.RequestId;
-            var timeStamp = shareProfileRequest.Timestamp.ToString();
-            var hipCode = shareProfileRequest.Profile.HipCode;
-            var patient = shareProfileRequest.Profile.PatientDemographics;
-            var response = await Save(new PatientQueue(requesId, timeStamp, patient, hipCode));
+            var hipCode = shareProfileRequest.Metadata.HipId;
+            var patient = shareProfileRequest.Profile.Patient;
+            var response = await Save(new PatientQueue(requestId, timestamp, patient, hipCode));
             if(response.HasValue)
                 Log.Information("Patient saved to queue");
             return response.ValueOrDefault();
@@ -65,8 +63,8 @@ namespace In.ProjectEKA.HipService.Patient
         public bool IsValidRequest(ShareProfileRequest shareProfileRequest)
         {
             var profile = shareProfileRequest?.Profile;
-            var demographics = profile?.PatientDemographics;
-            return demographics is {HealthId: { }, Identifiers: { }, Name: { },Gender:{}} && Enum.IsDefined(typeof(Gender), demographics.Gender) && demographics.YearOfBirth != 0;
+            var demographics = profile?.Patient;
+            return demographics is {AbhaAddress: { }, Name: { },Gender:{}} && Enum.IsDefined(typeof(Gender), demographics.Gender) && demographics.YearOfBirth != 0;
         }
         public async Task<List<PatientQueue>> GetPatientQueue()
         {
@@ -89,9 +87,9 @@ namespace In.ProjectEKA.HipService.Patient
         {
             var dob = new Date(patientDemographics.YearOfBirth, patientDemographics.MonthOfBirth ?? 1,
                 patientDemographics.DayOfBirth ?? 1).ToString();
-            var ndhmDemograhics = new NdhmDemographics(patientDemographics.HealthId, patientDemographics.Name,
+            var ndhmDemograhics = new NdhmDemographics(patientDemographics.AbhaAddress, patientDemographics.Name,
                 patientDemographics.Gender,
-                dob, patientDemographics.Identifiers[0].value);
+                dob, patientDemographics.PhoneNumber);
             var request = new HttpRequestMessage(HttpMethod.Post, hipConfiguration.Value.Url + PATH_DEMOGRAPHICS);
             request.Content = new StringContent(JsonConvert.SerializeObject(ndhmDemograhics), Encoding.UTF8,
                 "application/json");

--- a/src/In.ProjectEKA.HipService/Patient/PatientProfileService.cs
+++ b/src/In.ProjectEKA.HipService/Patient/PatientProfileService.cs
@@ -83,19 +83,6 @@ namespace In.ProjectEKA.HipService.Patient
             }
         }
 
-        public async Task linkToken(PatientDemographics patientDemographics)
-        {
-            var dob = new Date(patientDemographics.YearOfBirth, patientDemographics.MonthOfBirth ?? 1,
-                patientDemographics.DayOfBirth ?? 1).ToString();
-            var ndhmDemograhics = new NdhmDemographics(patientDemographics.AbhaAddress, patientDemographics.Name,
-                patientDemographics.Gender,
-                dob, patientDemographics.PhoneNumber);
-            var request = new HttpRequestMessage(HttpMethod.Post, hipConfiguration.Value.Url + PATH_DEMOGRAPHICS);
-            request.Content = new StringContent(JsonConvert.SerializeObject(ndhmDemograhics), Encoding.UTF8,
-                "application/json");
-            await httpClient.SendAsync(request).ConfigureAwait(false);
-        }
-
   
     }
 }

--- a/src/In.ProjectEKA.HipService/Patient/jobs/CleanPatientQueueJob.cs
+++ b/src/In.ProjectEKA.HipService/Patient/jobs/CleanPatientQueueJob.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using In.ProjectEKA.HipService.Logger;
+using In.ProjectEKA.HipService.OpenMrs;
+using In.ProjectEKA.HipService.Patient.Database;
+
+namespace In.ProjectEKA.HipService.Patient.jobs;
+
+public class CleanPatientQueueJob
+{
+    private readonly PatientContext patientContext;
+    private readonly OpenMrsConfiguration openMrsConfiguration;
+
+    public CleanPatientQueueJob(PatientContext patientContext, OpenMrsConfiguration openMrsConfiguration)
+    {
+        this.patientContext = patientContext;
+        this.openMrsConfiguration = openMrsConfiguration;
+    }
+
+    public void CleanPatientQueue()
+    {
+        List<PatientQueue> oldEntries = patientContext.PatientQueue.ToList().FindAll(
+            patient => DateTime.Now.Subtract(DateTime.Parse(patient.DateTimeStamp)).TotalMinutes >
+                       openMrsConfiguration.PatientQueueTimeLimit
+        );
+
+        patientContext.PatientQueue.RemoveRange(oldEntries);
+        patientContext.SaveChanges();
+
+        Log.Information($"Deleted {oldEntries.Count} old patient queue  at {DateTime.UtcNow}");
+    }
+}

--- a/src/In.ProjectEKA.HipService/Startup.cs
+++ b/src/In.ProjectEKA.HipService/Startup.cs
@@ -214,7 +214,8 @@ namespace In.ProjectEKA.HipService
                 .AddJwtBearer(Constants.GATEWAY_AUTH, options =>
                 {
                     // Need to validate Audience and Issuer properly
-                    options.Authority = $"{Configuration.GetValue<string>("Gateway:url")}/{Constants.CURRENT_VERSION}";
+                    options.Authority = $"{Configuration.GetValue<string>("Gateway:url")}/api/hiecm/gateway/v3/";
+                    options.BackchannelHttpHandler = new GatewayAuthHttpHandler(Configuration);
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
                         ValidateIssuerSigningKey = true,

--- a/src/In.ProjectEKA.HipService/Startup.cs
+++ b/src/In.ProjectEKA.HipService/Startup.cs
@@ -2,6 +2,7 @@ using In.ProjectEKA.HipService.Common.Model;
 using In.ProjectEKA.HipService.Creation;
 using In.ProjectEKA.HipService.Patient;
 using In.ProjectEKA.HipService.Patient.Database;
+using In.ProjectEKA.HipService.Patient.jobs;
 using In.ProjectEKA.HipService.SmsNotification;
 using In.ProjectEKA.HipService.UserAuth;
 using In.ProjectEKA.HipService.UserAuth.Database;
@@ -167,6 +168,7 @@ namespace In.ProjectEKA.HipService
                 .AddSingleton<ICollectHipService, CollectHipService>()
                 .AddScoped<IPatientDal, FhirDiscoveryDataSource>()
                 .AddScoped<IPhoneNumberRepository, OpenMrsPhoneNumberRepository>()
+                .AddScoped<CleanPatientQueueJob>()
                 .AddSingleton<EncryptionService>()
                 .AddTransient<IDataFlow, DataFlow.DataFlow>()
                 .AddRouting(options => options.LowercaseUrls = true)
@@ -274,6 +276,12 @@ namespace In.ProjectEKA.HipService
                     CancellationCheckInterval = TimeSpan.FromMinutes(
                         Configuration.GetSection("BackgroundJobs:cancellationCheckInterval").Get<int>())
                 });
+            RecurringJob.AddOrUpdate<CleanPatientQueueJob>(
+                "cleanup-patient-queue",
+                job => job.CleanPatientQueue(),
+                Cron.Hourly
+            );
+
 
             using var serviceScope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
             var linkContext = serviceScope.ServiceProvider.GetService<LinkPatientContext>();

--- a/src/In.ProjectEKA.HipService/appsettings.Development.json
+++ b/src/In.ProjectEKA.HipService/appsettings.Development.json
@@ -47,7 +47,7 @@
     "Uri": "http://localhost:9200"
   },
   "Gateway": {
-    "url": "https://dev.abdm.gov.in/gateway",
+    "url": "https://dev.abdm.gov.in",
     "timeout": 2000,
     "counter": 5,
     "clientId": "<add_clientID>",
@@ -62,7 +62,7 @@
     "username": "superman",
     "password": "Admin123",
     "phoneNumber": "phoneNumber",
-    "patientQueueTimeLimit": 30 //in_minutes
+    "patientQueueTimeLimit": 60 //in_minutes
   },
   "BackgroundJobs": {
     "cancellationCheckInterval": 5

--- a/src/In.ProjectEKA.HipService/appsettings.json
+++ b/src/In.ProjectEKA.HipService/appsettings.json
@@ -63,7 +63,7 @@
     "username": "superman",
     "password": "$OPENMRS_PASSWORD",
     "phoneNumber": "phoneNumber",
-    "patientQueueTimeLimit": 30 //in_minutes
+    "patientQueueTimeLimit": 60 //in_minutes
   },
   "BackgroundJobs": {
     "cancellationCheckInterval": 5


### PR DESCRIPTION
This PR refactors the APIs and the Payload and Response models for Scan and Share feature to use ABDM v3 APIs.
- A custom `GatewayAuthHttpHandler` is added to send `REQUEST-ID`, `TIMESTAMP`, `X-CM_ID` headers to the certs endpoint.
- A scheduler has been added which runs every Hour and cleans up old entries from the Patient Queue table
- Models related to callback API for scan and share request and reponse payload has been updated
 