### PR TITLE
BAH-4119 | Fix. Handle Null exception when OTP verification fails

### DIFF
--- a/src/In.ProjectEKA.HipService/Verification/VerificationController.cs
+++ b/src/In.ProjectEKA.HipService/Verification/VerificationController.cs
@@ -300,7 +300,7 @@ namespace In.ProjectEKA.HipService.Verification
                         AbhaAddressLoginVerifyOTPResponse gatewayResponse =
                             JsonConvert.DeserializeObject<AbhaAddressLoginVerifyOTPResponse>(responseContent);
                         HealthIdNumberTokenDictionary[sessionId] =
-                            new TokenRequest(gatewayResponse.tokens.token);
+                            new TokenRequest(gatewayResponse.tokens?.token);
                         AbhaAddressVerifyOtpResponse abhaAddressVerifyOtpResponse = new AbhaAddressVerifyOtpResponse()
                         {
                             AuthResult = gatewayResponse.authResult,


### PR DESCRIPTION
This PR fixes the Null Pointer exception when the OTP validation fails during ABHA address verification