### PR TITLE
BAH-4148 | Fix. Multi arch image build errors when built using QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - 'release-*'
-      - BAH-4148_patch
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           file: package/docker/Dockerfile
           push: true
           tags: bahmniindiadistro/hip:${{env.ARTIFACT_VERSION}},bahmniindiadistro/hip:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           file: package/docker/Dockerfile
           push: true
           tags: bahmniindiadistro/hip:${{env.ARTIFACT_VERSION}},bahmniindiadistro/hip:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - 'release-*'
+      - BAH-4148_patch
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 jobs:

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG TARGETARCH
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -6,15 +7,15 @@ COPY HipServiceSrc.sln ./
 COPY src/In.ProjectEKA.DefaultHip/*.csproj ./src/In.ProjectEKA.DefaultHip/
 COPY src/In.ProjectEKA.HipLibrary/*.csproj ./src/In.ProjectEKA.HipLibrary/
 COPY src/In.ProjectEKA.HipService/*.csproj ./src/In.ProjectEKA.HipService/
-RUN dotnet restore
+RUN dotnet restore -a $TARGETARCH
 
 # Copy everything else and build
 COPY . .
 WORKDIR /app/src/In.ProjectEKA.DefaultHip
-RUN dotnet build -c Release -o /app
+RUN dotnet build -c Release -o /app -a $TARGETARCH
 
 WORKDIR /app/src/In.ProjectEKA.HipService
-RUN dotnet publish -c Release -o /app
+RUN dotnet publish -c Release -o /app -a $TARGETARCH
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine


### PR DESCRIPTION
This PR fixes the issue with NuGet package errors when Docker image builds happen using QEMU for arm64 architectures on an amd64 host. This a known issue on NuGet. https://github.com/dotnet/sdk/issues/28971 && https://github.com/NuGet/Home/issues/12227

Solution Reference: https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/