### PR TITLE
BAH-4157 | Add. Wait time to wait for link confirmation to complete before health info request

### DIFF
--- a/src/In.ProjectEKA.HipService/DataFlow/DataFlow.cs
+++ b/src/In.ProjectEKA.HipService/DataFlow/DataFlow.cs
@@ -1,4 +1,5 @@
 using In.ProjectEKA.HipService.Link;
+using In.ProjectEKA.HipService.Logger;
 
 namespace In.ProjectEKA.HipService.DataFlow
 {
@@ -49,6 +50,12 @@ namespace In.ProjectEKA.HipService.DataFlow
             if (consent == null) return ConsentArtefactNotFound();
             var (patientUuid, _) =
                 await linkPatientRepository.GetPatientUuid(consent.ConsentArtefact.Patient.Id);
+            if (patientUuid.Equals(Guid.Empty))
+            {
+                Log.Information("Link Confirmation has not completed yet. Waiting for 1 second..");
+                await Task.Delay(1000);
+                (patientUuid, _) = await linkPatientRepository.GetPatientUuid(consent.ConsentArtefact.Patient.Id);
+            }
 
             var dataRequest = new DataRequest(consent.ConsentArtefact.CareContexts,
                 request.DateRange,


### PR DESCRIPTION
This PR adds a delay time while validating linked accounts to wait for link confirmation API to process before responding acknowledgement for `health-information/request` API.